### PR TITLE
Add static code analysis and make to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
 
     name: Foundry project
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,8 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,41 +31,10 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes && forge build --build-info
+          forge build --sizes 
         id: build
 
-      - name: Do a clean build with build info
+      - name: Run Forge tests
         run: |
-          cd packages/zksync-storage-contracts && forge build --build-info
-
-      - name: Echidna scan on StorageProofVerifier
-        uses: crytic/echidna-action@v2
-        with:
-          files: packages/zksync-storage-contracts
-          contract: StorageProofVerifier
-          crytic-args: --ignore-compile
-          test-mode: assertion
-
-      - name: Echidna scan on RegistryResolver
-        uses: crytic/echidna-action@v2
-        with:
-            files: packages/zksync-storage-contracts
-            contract: RegistryResolver
-            crytic-args: --ignore-compile
-            test-mode: assertion
-
-      - name: Echidna scan on SparseMerkleTree
-        uses: crytic/echidna-action@v2
-        with:
-            files: packages/zksync-storage-contracts
-            contract: SparseMerkleTree
-            crytic-args: --ignore-compile
-            test-mode: assertion
-
-      - name: Echidna scan on Blake2S
-        uses: crytic/echidna-action@v2
-        with:
-            files: packages/zksync-storage-contracts
-            contract: Blake2S
-            crytic-args: --ignore-compile
-            test-mode: assertion
+          forge test -vvv --root packages/zksync-storage-contracts
+        id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,3 @@ jobs:
           files: .
           contract: packages/zksync-storage-contracts
           crytic-args: --ignore-compile
-        env:
-          FOUNDRY_PROFILE: ci
-          INTERNAL_GITHUB_WORKSPACE: "/home/runner/work/zksync-storage-proofs/zksync-storage-proofs"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,25 +44,25 @@ jobs:
         with:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
-          crytic-args: 
+          crytic-args: --ignore-compile
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
-            crytic-args: 
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
-            crytic-args: 
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: Blake2S
-            crytic-args: 
+            crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,15 +34,9 @@ jobs:
           forge build --sizes && forge build --build-info
         id: build
 
-      - name: Run Forge tests
-        run: |
-          forge test -vvv --root packages/zksync-storage-contracts
-        id: test
-
       - name: Do a clean build with build info
         run: |
           cd packages/zksync-storage-contracts && forge build --build-info
-
 
       - name: Echidna scan on StorageProofVerifier
         uses: crytic/echidna-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,25 +49,25 @@ jobs:
         with:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
-          crytic-args: ""
+          crytic-args: --ignore-compile
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
-            crytic-args: ""
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
-            crytic-args: ""
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: Blake2S
-            crytic-args: ""
+            crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,17 @@ jobs:
         with:
           version: nightly
 
-      - name: Run Slither analysis on Solidity files
-        uses: crytic/slither-action@v0.4.0
-        with:
-          target: packages/zksync-storage-contracts
-
       - name: Run Forge build
         run: |
           forge --version
           forge build --sizes
         id: build
+
+      - name: Run Slither analysis on Solidity files
+        uses: crytic/slither-action@v0.4.0
+        with:
+          target: packages/zksync-storage-contracts
+          ignore-compile: true
 
       - name: Run Forge tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,27 @@ jobs:
         run: |
           forge test -vvv --root packages/zksync-storage-contracts
         id: test
+
+      - name: Echidna scan on StorageProofVerifier
+        uses: crytic/echidna-action@v2
+        with:
+          files: packages/zksync-storage-contracts
+          contract: StorageProofVerifier
+
+      - name: Echidna scan on RegistryResolver
+        uses: crytic/echidna-action@v2
+        with:
+            files: packages/zksync-storage-contracts
+            contract: RegistryResolver
+
+      - name: Echidna scan on SparseMerkleTree
+        uses: crytic/echidna-action@v2
+        with:
+            files: packages/zksync-storage-contracts
+            contract: SparseMerkleTree
+
+      - name: Echidna scan on Blake2S
+        uses: crytic/echidna-action@v2
+        with:
+            files: packages/zksync-storage-contracts
+            contract: Blake2S

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
 
     name: Foundry project
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --root packages/zksync-storage-contracts/test/SparseMerkleTree.t.sol
+          forge test -vvv
         id: test
 
       - name: Run Echidna for zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,6 @@ jobs:
           files: .
           contract: packages/zksync-storage-contracts
           crytic-args: --ignore-compile
+        env:
+          FOUNDRY_PROFILE: ci
+          INTERNAL_GITHUB_WORKSPACE: "/home/runner/work/zksync-storage-proofs/zksync-storage-proofs"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
           forge test -vvv --root packages/zksync-storage-contracts
         id: test
 
+      - name: Do a clean build with build info
+        run: |
+          cd packages/zksync-storage-contracts && forge build --build-info
+
+
       - name: Echidna scan on StorageProofVerifier
         uses: crytic/echidna-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Run Slither analysis on Solidity files
         uses: crytic/slither-action@v0.4.0
         with:
-          target: packages/zksync-storage-contracts
           ignore-compile: true
 
       - name: Run Forge build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,26 +43,26 @@ jobs:
         uses: crytic/echidna-action@v2
         with:
           files: StorageProofVerifier
-          contract: packages/zksync-storage-contracts
+          contract: packages/zksync-storage-contracts/src
           crytic-args: --ignore-compile
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
           files: SparseMerkleTree
-          contract: packages/zksync-storage-contracts
+          contract: packages/zksync-storage-contracts/src
           crytic-args: --ignore-compile
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
           files: Blake2S
-          contract: packages/zksync-storage-contracts
+          contract: packages/zksync-storage-contracts/src
           crytic-args: --ignore-compile
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
           files: RegistryResolver
-          contract: packages/zksync-storage-contracts
+          contract: packages/zksync-storage-contracts/src/demo
           crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,30 @@ jobs:
           forge test -vvv --root packages/zksync-storage-contracts
         id: test
 
-      - name: Run Echidna for zksync-storage-contracts
+      - name: Echidna scan on StorageProofVerifier
         uses: crytic/echidna-action@v2
         with:
-          files: .
+          files: StorageProofVerifier
+          contract: packages/zksync-storage-contracts
+          crytic-args: --ignore-compile
+
+      - name: Echidna scan on SparseMerkleTree
+        uses: crytic/echidna-action@v2
+        with:
+          files: SparseMerkleTree
+          contract: packages/zksync-storage-contracts
+          crytic-args: --ignore-compile
+
+      - name: Echidna scan on Blake2S
+        uses: crytic/echidna-action@v2
+        with:
+          files: Blake2S
+          contract: packages/zksync-storage-contracts
+          crytic-args: --ignore-compile
+
+      - name: Echidna scan on RegistryResolver
+        uses: crytic/echidna-action@v2
+        with:
+          files: RegistryResolver
           contract: packages/zksync-storage-contracts
           crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,26 +43,22 @@ jobs:
         uses: crytic/echidna-action@v2
         with:
           files: StorageProofVerifier
-          contract: packages/zksync-storage-contracts/src
-          crytic-args: --ignore-compile
+          contract: packages/zksync-storage-contracts
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
           files: SparseMerkleTree
-          contract: packages/zksync-storage-contracts/src
-          crytic-args: --ignore-compile
+          contract: packages/zksync-storage-contracts
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
           files: Blake2S
-          contract: packages/zksync-storage-contracts/src
-          crytic-args: --ignore-compile
+          contract: packages/zksync-storage-contracts
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
           files: RegistryResolver
-          contract: packages/zksync-storage-contracts/src/demo
-          crytic-args: --ignore-compile
+          contract: packages/zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --root packages/zksync-storage-contracts/test
+          forge test -vvv --root packages/zksync-storage-contracts/test/SparseMerkleTree.t.sol
         id: test
 
       - name: Run Echidna for zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,25 +44,25 @@ jobs:
         with:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
-          crytic-args: --ignore-compile
+          crytic-args: 
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
-            crytic-args: --ignore-compile
+            crytic-args: 
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
-            crytic-args: --ignore-compile
+            crytic-args: 
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: Blake2S
-            crytic-args: --ignore-compile
+            crytic-args: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,17 +22,17 @@ jobs:
         with:
           version: nightly
 
-      - name: Run Forge build
-        run: |
-          forge --version
-          forge build --sizes
-        id: build
-
       - name: Run Slither analysis on Solidity files
         uses: crytic/slither-action@v0.4.0
         with:
           target: packages/zksync-storage-contracts
           ignore-compile: true
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --sizes
+        id: build
 
       - name: Run Forge tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --root packages/zksync-storage-contracts/test
         id: test
 
       - name: Run Echidna for zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           version: nightly
 
+      - name: Run Slither analysis on Solidity files
+        uses: crytic/slither-action@v0.4.0
+        with:
+          target: packages/zksync-storage-contracts
+
       - name: Run Forge build
         run: |
           forge --version
@@ -32,3 +37,10 @@ jobs:
         run: |
           forge test -vvv
         id: test
+
+      - name: Run Echidna for zksync-storage-contracts
+        uses: crytic/echidna-action@v2
+        with:
+          files: .
+          contract: packages/zksync-storage-contracts
+          crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,27 +38,3 @@ jobs:
         run: |
           forge test -vvv --root packages/zksync-storage-contracts
         id: test
-
-      - name: Echidna scan on StorageProofVerifier
-        uses: crytic/echidna-action@v2
-        with:
-          files: StorageProofVerifier
-          contract: packages/zksync-storage-contracts
-
-      - name: Echidna scan on SparseMerkleTree
-        uses: crytic/echidna-action@v2
-        with:
-          files: SparseMerkleTree
-          contract: packages/zksync-storage-contracts
-
-      - name: Echidna scan on Blake2S
-        uses: crytic/echidna-action@v2
-        with:
-          files: Blake2S
-          contract: packages/zksync-storage-contracts
-
-      - name: Echidna scan on RegistryResolver
-        uses: crytic/echidna-action@v2
-        with:
-          files: RegistryResolver
-          contract: packages/zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes
+          forge build --sizes && forge build --build-info
         id: build
 
       - name: Run Forge tests
@@ -44,21 +44,25 @@ jobs:
         with:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
+          crytic-args: --ignore-compile
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
+            crytic-args: --ignore-compile
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: Blake2S
+            crytic-args: --ignore-compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
           crytic-args: --ignore-compile
+          test-mode: assertion
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
@@ -51,6 +52,7 @@ jobs:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
             crytic-args: --ignore-compile
+            test-mode: assertion
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
@@ -58,6 +60,7 @@ jobs:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
             crytic-args: --ignore-compile
+            test-mode: assertion
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
@@ -65,3 +68,4 @@ jobs:
             files: packages/zksync-storage-contracts
             contract: Blake2S
             crytic-args: --ignore-compile
+            test-mode: assertion

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --root packages/zksync-storage-contracts
         id: test
 
       - name: Run Echidna for zksync-storage-contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,25 +44,25 @@ jobs:
         with:
           files: packages/zksync-storage-contracts
           contract: StorageProofVerifier
-          crytic-args: --ignore-compile
+          crytic-args: ""
 
       - name: Echidna scan on RegistryResolver
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: RegistryResolver
-            crytic-args: --ignore-compile
+            crytic-args: ""
 
       - name: Echidna scan on SparseMerkleTree
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: SparseMerkleTree
-            crytic-args: --ignore-compile
+            crytic-args: ""
 
       - name: Echidna scan on Blake2S
         uses: crytic/echidna-action@v2
         with:
             files: packages/zksync-storage-contracts
             contract: Blake2S
-            crytic-args: --ignore-compile
+            crytic-args: ""

--- a/packages/zksync-storage-contracts/foundry.toml
+++ b/packages/zksync-storage-contracts/foundry.toml
@@ -1,5 +1,4 @@
 [profile.default]
-src = "src"
 out = "out"
 libs = ["lib"]
 

--- a/packages/zksync-storage-contracts/foundry.toml
+++ b/packages/zksync-storage-contracts/foundry.toml
@@ -2,6 +2,13 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+test = "test"
+
+[profile.ci]
+src = "src"
+test = "test"
+out = "out"
+libs = ["lib"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 optimizer = true

--- a/packages/zksync-storage-contracts/foundry.toml
+++ b/packages/zksync-storage-contracts/foundry.toml
@@ -2,13 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-test = "test"
-
-[profile.ci]
-src = "src"
-test = "test"
-out = "out"
-libs = ["lib"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 optimizer = true

--- a/packages/zksync-storage-contracts/foundry.toml
+++ b/packages/zksync-storage-contracts/foundry.toml
@@ -1,4 +1,5 @@
 [profile.default]
+src = "src"
 out = "out"
 libs = ["lib"]
 


### PR DESCRIPTION
-Added Slither as static analysis tool to make sure that bugs and other potential vulnerabilities in the contracts being detected earlier in development
-Decided to add `--root packages/zksync-storage-contracts` to `forge test -vvv` as the test.yml pipeline didn't work with the original command as it gave no tests to run, however, with using `--root` command for `forge test`, the pipeline worked perfectly.